### PR TITLE
Download SVG of generated path

### DIFF
--- a/nautobot/dcim/templates/dcim/cable_trace.html
+++ b/nautobot/dcim/templates/dcim/cable_trace.html
@@ -67,6 +67,7 @@
                                 <div class="trace-end">
                                     <button type="button" id="download-btn" class="btn btn-default">Download SVG</button>
                                     <script>
+                                        //Download SVG of generated trace diagram
                                         document.getElementById("download-btn").addEventListener("click", function () {
                                             const traceElement = document.getElementById("cable-trace");
                                             const downloadButton = document.getElementById("download-btn");
@@ -145,13 +146,11 @@
                                             foreignObject.setAttribute("height", "100%");
                                             foreignObject.appendChild(clonedTrace);
                                             svgElement.appendChild(foreignObject);
-                                        
-                                            // Serialize SVG
+                                    
                                             const svgData = serializer.serializeToString(svgElement);
                                             const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
                                             const url = URL.createObjectURL(blob);
                                         
-                                            // Download SVG
                                             const link = document.createElement("a");
                                             link.href = url;
                                             link.download = "cable_trace.svg";


### PR DESCRIPTION
## Download the SVG of generated path
<img width="943" alt="download_svg" src="https://github.com/user-attachments/assets/2bd5304b-f19d-47de-9d01-9b93ccdb710d" />


## Downloaded SVG
<img width="407" alt="downloaded_svg" src="https://github.com/user-attachments/assets/5c607de3-3be9-4a3c-81fc-09a79641d2db" />
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #<ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
I've added Download SVG button in cable_trace.html that downloads the SVG format of the path generated. The SVG image contains clickable links of every segment of the path just like the generated path

The above feature involves minimal code changes, just a small script written in JS, which is triggered when the Download SVG button is clicked

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
